### PR TITLE
Update plugin to comply with Store requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ API Monkey is a Stream Deck plugin for sending HTTP requests and displaying the 
 
 - Windows 10 or later, x64
 - macOS 10.15 or later, Apple silicon
-- Stream Deck 6.4 or later
+- Stream Deck 6.9 or later
 
 ## Installation
 

--- a/resources/manifest.json
+++ b/resources/manifest.json
@@ -38,8 +38,8 @@
       "MinimumVersion": "10.15"
     }
   ],
-  "SDKVersion": 2,
+  "SDKVersion": 3,
   "Software": {
-    "MinimumVersion": "6.4"
+    "MinimumVersion": "6.9"
   }
 }


### PR DESCRIPTION
## Summary

- require Stream Deck 6.9 or later
- declare Stream Deck SDK version 3 compatibility
- update documented compatibility

DRM protection is applied by Maker Console after upload.

## Verification

- `make lint`
- `go test -count=1 -p 1 -timeout 60s ./...`
- `go build ./...`
- `jq empty resources/manifest.json`